### PR TITLE
Trying to reproduce the failure locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 #### Docker Env
 
-* Build the `io.micrometer.publishing/prometheus-rsocket-proxy:0.8.0-snapshot` image locally from the `prometheus-rsocket-proxy` project:
-
-```
-./gradlew build docker 
-```
-
 * Build the `springcloud/spring-cloud-dataflow-prometheus-local:rsocket` image locally.
 
 Change directory to `src/main/resources/docker-compose/prometheus-local` and run:
@@ -23,3 +17,7 @@ Change directory to `src/main/resources/docker-compose/` and run:
 ```
 docker-compose -f ./docker-compose-rsocket.yml up
 ```
+
+* Run the Demo application
+
+Run the Java main for `PrometheusRsocketDemoApplication` in the IDE or with `java -jar target/prometheus-rsocket-demo-0.0.1-SNAPSHOT` on the built project from the project root directory.

--- a/pom.xml
+++ b/pom.xml
@@ -16,26 +16,23 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-<!--		<prometheus-rsocket-spring.version>0.8.0-SNAPSHOT</prometheus-rsocket-spring.version>-->
 		<prometheus-rsocket-spring.version>0.8.0-SNAPSHOT</prometheus-rsocket-spring.version>
-		<micrometer.version>1.1.5</micrometer.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>io.micrometer.publishing</groupId>
+			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-spring</artifactId>
 			<version>${prometheus-rsocket-spring.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.micrometer.publishing</groupId>
+			<groupId>io.micrometer.prometheus</groupId>
 			<artifactId>prometheus-rsocket-client</artifactId>
 			<version>${prometheus-rsocket-spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
-			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -72,7 +69,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/libs-snapshot-local</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -80,7 +77,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/libs-milestone-local</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/src/main/resources/docker-compose/docker-compose-rsocket.yml
+++ b/src/main/resources/docker-compose/docker-compose-rsocket.yml
@@ -6,18 +6,18 @@ services:
 #    image: springcloud/spring-cloud-dataflow-grafana-prometheus:${DATAFLOW_VERSION}
 #    container_name: grafana
 #    ports:
-      - '3000:3000'
+#      - '3000:3000'
 
   prometheus:
     image: springcloud/spring-cloud-dataflow-prometheus-local:rsocket
     container_name: prometheus
-    volumes:
-      - 'scdf-targets:/etc/prometheus/'
+#    volumes:
+#      - 'scdf-targets:/etc/prometheus/'
     ports:
       - '9090:9090'
 
   prometheus-rsocket-proxy:
-    image: io.micrometer.publishing/prometheus-rsocket-proxy:0.8.0-snapshot
+    image: micrometermetrics/prometheus-rsocket-proxy:0.8.0-SNAPSHOT
     container_name: prometheus-rsocket-proxy
     expose:
       - '9096'
@@ -30,5 +30,5 @@ services:
     environment:
       - server.port=9096
 
-volumes:
-  scdf-targets:
+#volumes:
+#  scdf-targets:


### PR DESCRIPTION
I changed some things to minimize potential sources of variability and make sure the latest code was being used. I'm not able to reproduce the failure reported in https://github.com/micrometer-metrics/prometheus-rsocket-proxy/issues/14

* https://github.com/micrometer-metrics/prometheus-rsocket-proxy/issues/17 changed the group ID, so the latest code will be in the `io.micrometer.prometheus` group id.
* https://github.com/micrometer-metrics/prometheus-rsocket-proxy/issues/16 publishes the Docker image for snapshot builds now, so we can use that directly
* I added the instruction to run the demo application, which did not reproduce the error.